### PR TITLE
Fix for #295 - disallow DTD entities on workspace files

### DIFF
--- a/src/husacct/control/task/resources/XmlResource.java
+++ b/src/husacct/control/task/resources/XmlResource.java
@@ -21,6 +21,10 @@ public class XmlResource implements IResource{
 		File file = (File) dataValues.get("file");
 
 		SAXBuilder sax = new SAXBuilder();
+		sax.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
+		sax.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		sax.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
 		Document doc = new Document();
 		try {
 


### PR DESCRIPTION
As mentioned in #295, the commit sets the configuration for the `SAXBuilder` in order to disallow the use of DTD entities on workspace files.

