### PR TITLE
HUSACCT weer buildend krijgen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,18 @@
 
     <name>HUSACCT</name>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-imaging -->
+        <!-- dit is een transitieve dependency van com.itextpdf.itextpdf
+             in die versie wordt echter een SNAPSHOT gevraagd die soms niet downloadbaar is
+             alpha is ook niet prettig, maar er is gewoon geen 1.0 versie van deze library,
+             en alpha is op z'n minst iets stabieler dan SNAPSHOT.
+             Alternetief is een geresolvede versie jar-en-al inchecken in local-maven-repo -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-imaging</artifactId>
+            <version>1.0-alpha2</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.antlr/antlr4 -->
         <dependency>
             <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
 
     <build>
         <sourceDirectory>${project.basedir}/src</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/husaccttest</testSourceDirectory>
         <resources>
             <resource>
                 <directory>${project.basedir}/src/</directory>
@@ -198,6 +199,15 @@
                             <mainClass>husacct.Main</mainClass>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+
                 </configuration>
             </plugin>
         </plugins>

--- a/src/husacct/control/task/help/HelpTreeModelLoader.java
+++ b/src/husacct/control/task/help/HelpTreeModelLoader.java
@@ -14,6 +14,9 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -67,10 +70,11 @@ public class HelpTreeModelLoader {
 	}
 	
 	private DefaultMutableTreeNode findNode(DefaultMutableTreeNode root, HelpTreeNode node) {
-		List<DefaultMutableTreeNode> Children = Collections.list(root.children());
-		for(int i = 0; i < Children.size(); i++) {
-			if(((HelpTreeNode)Children.get(i).getUserObject()).getFilename().equals(node.getFilename())) {
-				return Children.get(i);
+		List<TreeNode> children = Collections.list(root.children());
+		for(int i = 0; i < children.size(); i++) {
+			DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) children.get(i);
+			if(((HelpTreeNode)childNode.getUserObject()).getFilename().equals(node.getFilename())) {
+				return childNode;
 			}
 		}
 		return new DefaultMutableTreeNode(node);

--- a/src/husacct/externalinterface/ExternalServiceProvider.java
+++ b/src/husacct/externalinterface/ExternalServiceProvider.java
@@ -81,7 +81,7 @@ public class ExternalServiceProvider {
 	private static void setLog4jConfiguration() {
 		Properties props = new Properties();
 		try {
-			props.load(Class.class.getResourceAsStream("/husacct/common/resources/log4j.properties"));
+			props.load(husacct.Main.class.getResourceAsStream("/husacct/common/resources/log4j.properties"));
 		} catch (IOException e) {
 			System.out.println("IOException in HUSACCT ExternalServiceProvider.setLog4jConfiguration()");
 			//e.printStackTrace();

--- a/src/husaccttest/SaccOnHusacct.java
+++ b/src/husaccttest/SaccOnHusacct.java
@@ -151,7 +151,7 @@ public class SaccOnHusacct {
 
 	
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 	}
 	

--- a/src/husaccttest/analyse/ArchitectureReconstructionTest_SRMA.java
+++ b/src/husaccttest/analyse/ArchitectureReconstructionTest_SRMA.java
@@ -221,7 +221,7 @@ public class ArchitectureReconstructionTest_SRMA {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(ArchitectureReconstructionTest_SRMA.class);
 	}

--- a/src/husaccttest/analyse/CSharp_AccuracyTestDependencyDetection.java
+++ b/src/husaccttest/analyse/CSharp_AccuracyTestDependencyDetection.java
@@ -1187,7 +1187,7 @@ public class CSharp_AccuracyTestDependencyDetection {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(CSharp_AccuracyTestDependencyDetection.class);
 	}

--- a/src/husaccttest/analyse/ExportImportAnalysedModelTest.java
+++ b/src/husaccttest/analyse/ExportImportAnalysedModelTest.java
@@ -222,7 +222,7 @@ public class ExportImportAnalysedModelTest {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(ExportImportAnalysedModelTest.class);
 	}

--- a/src/husaccttest/analyse/Java_AccuracyTestDependencyDetection.java
+++ b/src/husaccttest/analyse/Java_AccuracyTestDependencyDetection.java
@@ -1401,7 +1401,7 @@ public class Java_AccuracyTestDependencyDetection {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(Java_AccuracyTestDependencyDetection.class);
 	}

--- a/src/husaccttest/analyse/ReconstructAlgorithmTests.java
+++ b/src/husaccttest/analyse/ReconstructAlgorithmTests.java
@@ -205,7 +205,7 @@ public class ReconstructAlgorithmTests {
 	
 	
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(ExportImportAnalysedModelTest.class);
 	}

--- a/src/husaccttest/control/LocaleControllerTest.java
+++ b/src/husaccttest/control/LocaleControllerTest.java
@@ -29,7 +29,7 @@ public class LocaleControllerTest {
 	}
 
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(LocaleControllerTest.class);
 	}

--- a/src/husaccttest/define/DefineServicesTest_SRMA.java
+++ b/src/husaccttest/define/DefineServicesTest_SRMA.java
@@ -285,7 +285,7 @@ public class DefineServicesTest_SRMA {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(DefineServicesTest_SRMA.class);
 	}

--- a/src/husaccttest/graphics/DrawingControllerTest.java
+++ b/src/husaccttest/graphics/DrawingControllerTest.java
@@ -344,7 +344,7 @@ public class DrawingControllerTest {
 	//private helpers
 	//
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 		logger = Logger.getLogger(DrawingControllerTest.class);
 	}

--- a/src/husaccttest/validate/SACCandSRMAtest.java
+++ b/src/husaccttest/validate/SACCandSRMAtest.java
@@ -414,7 +414,7 @@ public class SACCandSRMAtest {
 	// Private helpers
 	
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 	}
 }

--- a/src/husaccttest/validate/ValidateTest.java
+++ b/src/husaccttest/validate/ValidateTest.java
@@ -294,7 +294,7 @@ public class ValidateTest {
 	}
 
 	private static void setLog4jConfiguration() {
-		URL propertiesFile = Class.class.getResource("/husacct/common/resources/log4j.properties");
+		URL propertiesFile = husacct.Main.class.getResource("/husacct/common/resources/log4j.properties");
 		PropertyConfigurator.configure(propertiesFile);
 	}
 }


### PR DESCRIPTION
Bij het uitchecken van de code kreeg ik een compile error op een Generic constraint die tegenwoordig iets strakker ligt. 

Verder draaiden de unit-tests niet omdat de log4j.properties niet meer gevonden kon worden. Als non-java programmeur was dat even zoeken, maar het lijkt erop dat tegenwoordig (ik vermoed sinds het Java 9 module-systeem) Class.class.getResource() zoekt naar resource files ergens binnen je SDK.

Door te zorgen dat er in elk geval -binnen- het huidige project gezocht werd werkt 'ant test' weer.

