### PR TITLE
Fixed order-dependent null-pointer in ViewController

### DIFF
--- a/src/husacct/control/presentation/viewcontrol/ViewController.java
+++ b/src/husacct/control/presentation/viewcontrol/ViewController.java
@@ -18,12 +18,10 @@ public class ViewController {
 	private InternalFrameController validateConfigurationContainer;
 	private InternalFrameController codeViewerContainer;
 	private InternalFrameController analyseSARController;
-	private JFrame mainFrame;
 	
 	private List<InternalFrameController> viewContainers = new ArrayList<>();
 
 	public ViewController(MainController mainController){
-		this.mainFrame = mainController.getMainGui();
 
 		defineContainer = new InternalFrameController(mainController, new ImageIcon(Resource.get(Resource.ICON_DEFINE_ARCHITECTURE)), "DefineArchitecture"){
 			@Override
@@ -57,7 +55,7 @@ public class ViewController {
 		analyseSARController = new InternalFrameController(mainController, new ImageIcon(Resource.get(Resource.ICON_APPLICATION_OVERVIEW)), "SoftwareArchitectureReconstruction") {
 			@Override
 			public JInternalFrame getNewInternalFrame() {
-				return ServiceProvider.getInstance().getAnalyseService().getSARDialog(ViewController.this.mainFrame);
+				return ServiceProvider.getInstance().getAnalyseService().getSARDialog(mainController.getMainGui());
 			}
 		};
 		


### PR DESCRIPTION
I had not assumed getMainGui() could return null, but it does for a little while at startup, so I should not store the reference

I'm tempted to add a lot of Objects.requireNotNull in places. I'd prefer the application to crash harder in these cases so these little bugs don't go undetected and turn into bigger ones.