### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,6 +20,6 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'zulu'
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -13,13 +13,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11, 17-ea ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'zulu'
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,10 +18,10 @@ jobs:
         java-version: [ 11, 17-ea ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        java-version: ${{ matrix.java }}
+        java-version: ${{ matrix.java-version }}
         distribution: 'zulu'
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. Also, added a matrix with JDK 11 and 17-ea. JDK 17 is the new LTS version.
