### PR TITLE
Fix bug related to hiding modules with DEL key

### DIFF
--- a/src/husacct/graphics/domain/DrawingView.java
+++ b/src/husacct/graphics/domain/DrawingView.java
@@ -110,7 +110,12 @@ public class DrawingView extends DefaultDrawingView {
 	private boolean hasSelection() {
 		return getSelectedFigures().size() > 0;
 	}
-	
+
+	@Override
+	public void delete() {
+		hideSelectedFigures();
+	}
+
 	public void hideSelectedFigures() {
 		Set<Figure> selection = getSelectedFigures();
 		drawing.hideSelectedFigures(selection);


### PR DESCRIPTION
jhotdraw has an internal event listener that calls the method `DefaultDrawing.delete()` which removes the selected shape when the DELETE key is pressed. This ignores extra logic added by HUSACCT and thus creates the wierd artifacts seen in #309. Overriding
this logic fixes the problem.

---

However, I have noticed the `DEL` key not functioning at all frequently, unsure why this is happening.